### PR TITLE
Support for JCEKS SecretKeys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ nosetests.xml
 .project
 .pydevproject
 .idea
+.*.swp

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ for c in ks.certs:
     print "Certificate: %s" % c.alias
     print_pem(c.cert, "CERTIFICATE")
     print
+
+for sk in ks.secret_keys:
+    print "Secret key: %s" % sk.alias
+    print "  Algorithm: %s" % sk.algorithm
+    print "  Key size: %d bits" % sk.size
+    print "  Key: "+(''.join(x.encode('hex') for x in sk.key))
 ```
 
 

--- a/jks/jks.py
+++ b/jks/jks.py
@@ -1,3 +1,4 @@
+# vim: set et ai ts=4 sts=4 sw=4:
 '''
 JKS/JCEKS file format decoder.
 Use in conjunction with PyOpenSSL to translate to PEM, or load private key and certs
@@ -7,14 +8,18 @@ See http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/6-b14
 See http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/6-b27/com/sun/crypto/provider/JceKeyStore.java#JceKeyStore
 '''
 import struct
+import ctypes
 import hashlib
 import collections
+import StringIO
+import javaobj
 from pyasn1.codec.ber import decoder
 
 class KeyStore(object):
-    def __init__(self, private_keys, certs):
+    def __init__(self, private_keys, certs, secret_keys):
         self.private_keys = private_keys
         self.certs = certs
+        self.secret_keys = secret_keys
 
     @classmethod
     def load(cls, filename, password):
@@ -32,15 +37,16 @@ class KeyStore(object):
         else:
             raise ValueError('Not a JKS or JCEKS keystore (magic number wrong; expected FEEDFEED resp. CECECECE)')
 
+        private_keys = []
+        secret_keys = []
+        certs = []
+
         version = b4.unpack_from(data, 4)[0]
         if version != 2:
             raise ValueError('Unsupported keystore version; only v2 supported, found v'+repr(version))
 
         entry_count = b4.unpack_from(data, 8)[0]
         pos = 12
-        private_keys = []
-        certs = []
-
         for i in range(entry_count):
             tag = b4.unpack_from(data, pos)[0]
             pos += 4
@@ -73,7 +79,8 @@ class KeyStore(object):
                     if algo_id == SUN_JKS_ALGO_ID:
                         plaintext = _sun_jks_pkey_decrypt(encrypted_private_key, password)
                     elif algo_id == SUN_JCE_ALGO_ID:
-                        salt = asn1_data[0][0][1][0].asOctets() # see section A.3: PBES1 and definitions of AlgorithmIdentifier and PBEParameter in RFC 2898
+                        # see RFC 2898, section A.3: PBES1 and definitions of AlgorithmIdentifier and PBEParameter
+                        salt = asn1_data[0][0][1][0].asOctets()
                         iteration_count = int(asn1_data[0][0][1][1])
                         plaintext = _sun_jce_pkey_decrypt(encrypted_private_key, password, salt, iteration_count)
                     else:
@@ -90,28 +97,130 @@ class KeyStore(object):
             elif tag == 3:
                 if filetype != 'jceks':
                     raise ValueError("Unexpected entry tag {0} encountered in JKS keystore; only supported in JCEKS keystores".format(tag))
-                # TODO: implement me
+
+                # SecretKeys are stored in the key store file through Java's serialization mechanism, i.e. as an actual serialized Java object
+                # embedded inside the file. The objects that get stored are not the SecretKey instances themselves though, as that would trivially
+                # expose the key without the need for a passphrase to gain access to it.
+                #
+                # Instead, an object of type javax.crypto.SealedObject is written. The purpose of this class is specifically to securely
+                # serialize objects that contain secret values by applying a password-based encryption scheme to the serialized form of the object
+                # to be protected. Only the resulting ciphertext is then stored by the serialized form of the SealedObject instance.
+                #
+                # To decrypt the SealedObject, the correct passphrase must be given to be able to decrypt the underlying object's serialized form.
+                # Once decrypted, one more de-serialization will result in the original object being restored.
+                #
+                # The default key protector used by the SunJCE provider returns an instance of type SealedObjectForKeyProtector, a (direct)
+                # subclass of SealedObject, which uses Java's custom/unpublished PBEWithMD5AndTripleDES algorithm.
+                #
+                # Class member structure:
+                #
+                # SealedObjectForKeyProtector:
+                #   static final long serialVersionUID = -3650226485480866989L;
+                #
+                # SealedObject:
+                #   static final long serialVersionUID = 4482838265551344752L;
+                #   private byte[] encryptedContent;         # The serialized underlying object, in encrypted format.
+                #   private String sealAlg;                  # The algorithm that was used to seal this object.
+                #   private String paramsAlg;                # The algorithm of the parameters used.
+                #   protected byte[] encodedParams;          # The cryptographic parameters used by the sealing Cipher, encoded in the default format.
+
+                sealed_obj, pos = _read_java_obj(data, pos)
+                if not _java_instanceof(sealed_obj, "javax.crypto.SealedObject"):
+                    raise ValueError("Unexpected sealed object type '%s'; not a subclass of javax.crypto.SealedObject" % sealed_obj.get_class().name)
+
+                sealed_obj.encodedParams = _java_bytestring(sealed_obj.encodedParams)
+                sealed_obj.encryptedContent = _java_bytestring(sealed_obj.encryptedContent)
+
+                salt = 0
+                iteration_count = 0
+                plaintext = ""
+
+                params_asn1 = decoder.decode(sealed_obj.encodedParams)
+                if sealed_obj.paramsAlg == "PBEWithMD5AndTripleDES" and sealed_obj.sealAlg == "PBEWithMD5AndTripleDES":
+                    salt = params_asn1[0][0].asOctets()
+                    iteration_count = int(params_asn1[0][1])
+                    plaintext = _sun_jce_pkey_decrypt(sealed_obj.encryptedContent, password, salt, iteration_count)
+                else:
+                    raise ValueError("Unexpected sealAlg and paramsAlg combination: sealAlg=%s, paramsAlg=%s" % (sealed_obj.sealAlg, sealed_obj.paramsAlg))
+
+                # The plaintext here is another serialized Java object; this time it's an object implementing the javax.crypto.SecretKey interface.
+                # When using the default SunJCE provider, these are usually either javax.crypto.spec.SecretKeySpec objects, or some other specialized ones
+                # like those found in the com.sun.crypto.provider package (e.g. DESKey and DESedeKey).
+                #
+                # Additionally, things are further complicated by the fact that some of these specialized SecretKey implementations (i.e. other than SecretKeySpec)
+                # implement a writeReplace() method, causing Java's serialization runtime to swap out the object for a completely different one at serialization time.
+                # Again for SunJCE, the subsitute object that gets serialized is usually a java.security.KeyRep object.
+
+                obj, dummy = _read_java_obj(plaintext, 0)
+                clazz = obj.get_class()
+                if clazz.name == "javax.crypto.spec.SecretKeySpec":
+                    key_algorithm = obj.algorithm
+                    key_bytes = _java_bytestring(obj.key)
+                    key_size = len(key_bytes)*8
+                    secret_keys.append(SecretKey(alias, timestamp, key_algorithm, key_bytes, key_size))
+                elif clazz.name == "java.security.KeyRep":
+                    assert obj.type == "SECRET", "Expected value 'SECRET' for KeyRep.type enum value, found '%s'" % obj.type
+                    key_algorithm = obj.algorithm
+                    key_encoding = obj.format
+                    key_bytes = _java_bytestring(obj.encoded)
+                    if key_encoding == "RAW":
+                        pass # ok, no further processing needed
+                    elif key_encoding == "X.509":
+                        raise NotImplementedError("X.509 encoding for KeyRep objects not yet implemented")
+                    elif key_encoding == "PKCS#8":
+                        raise NotImplementedError("PKCS#8 encoding for KeyRep objects not yet implemented")
+                    else:
+                        raise ValueError("Unexpected key encoding '%s' found in serialized java.security.KeyRep object; expected one of 'RAW', 'X.509', 'PKCS#8'." % key_encoding)
+
+                    key_size = len(key_bytes)*8
+                    secret_keys.append(SecretKey(alias, timestamp, key_algorithm, key_bytes, key_size))
+                else:
+                    raise ValueError("Unexpected object of type '%s' found inside SealedObject; don't know how to handle it" % obj['_name'])
+
+            else:
+                raise ValueError("Unexpected keystore entry tag %d", tag)
 
         # the keystore integrity check uses the UTF-16BE encoding of the password
         password_utf16 = password.encode('utf-16be')
-        if hashlib.sha1(password_utf16 + SIGNATURE_WHITENING + data[:pos]).digest() != data[pos:]:
+        expected_hash = hashlib.sha1(password_utf16 + SIGNATURE_WHITENING + data[:pos]).digest()
+        if expected_hash != data[pos:]:
             raise ValueError("Hash mismatch; incorrect password or data corrupted")
 
-        return cls(private_keys, certs)
+        return cls(private_keys, certs, secret_keys)
 
 Cert = collections.namedtuple("Cert", "alias timestamp type cert")
 PrivateKey = collections.namedtuple("PrivateKey", "alias timestamp pkey cert_chain")
+SecretKey = collections.namedtuple("SecretKey", "alias timestamp algorithm key size")
 
 b8 = struct.Struct('>Q')
 b4 = struct.Struct('>L')
 b2 = struct.Struct('>H')
+b1 = struct.Struct('B')
 
 MAGIC_NUMBER_JKS = b4.pack(0xFEEDFEED)
 MAGIC_NUMBER_JCEKS = b4.pack(0xCECECECE)
 VERSION = b4.pack(2)
 SIGNATURE_WHITENING = b"Mighty Aphrodite"
 SUN_JKS_ALGO_ID = (1,3,6,1,4,1,42,2,17,1,1) # JavaSoft proprietary key-protection algorithm
-SUN_JCE_ALGO_ID = (1,3,6,1,4,1,42,2,19,1)   # PBE_WITH_MD5_AND_DES3_CBC_OID
+SUN_JCE_ALGO_ID = (1,3,6,1,4,1,42,2,19,1)   # PBE_WITH_MD5_AND_DES3_CBC_OID (non-published, modified version of PKCS#5 PBEWithMD5AndDES)
+
+def _java_instanceof(obj, class_name):
+    """Given a deserialized JavaObject as returned by the javaobj library, determine whether it's a subclass of the given class name."""
+    clazz = obj.get_class()
+    while clazz:
+        if clazz.name == class_name:
+            return True
+        clazz = clazz.superclass
+    return False
+
+def _java_bytestring(java_byte_list):
+    """
+    Convert the value returned by javaobj for a byte[] to a byte string.
+    Java's bytes are signed and numeric (i.e. not chars), so javaobj returns Java byte arrays as a list of Python integers in the range [-128, 127].
+    For ease of use we want to get a byte string representation of that, so we reinterpret each integer as an unsigned byte, take its new value
+    as another Python int (now remapped to the range [0, 255]), and use struct.pack() to create the matching byte string.
+    """
+    return struct.pack("%dB" % len(java_byte_list), *[ctypes.c_ubyte(sb).value for sb in java_byte_list])
 
 def _read_utf(data, pos):
     size = b2.unpack_from(data, pos)[0]
@@ -145,7 +254,7 @@ def _sun_jce_pkey_decrypt(data, password, salt, iteration_count):
     key, iv = _sun_jce_derive_cipher_key_iv(password, salt, iteration_count)
 
     from Crypto.Cipher import DES3
-    des3 = DES3.new(key, DES3.MODE_CBC, IV=iv) # apparently uses EDE, although there's no apparent way to tell it what to use ...
+    des3 = DES3.new(key, DES3.MODE_CBC, IV=iv)
     padded = des3.decrypt(data)
 
     result = _strip_pkcs5_padding(padded)
@@ -154,7 +263,7 @@ def _sun_jce_pkey_decrypt(data, password, salt, iteration_count):
 def _sun_jce_derive_cipher_key_iv(password, salt, iteration_count):
     '''
     PKCS#8-formatted private key with a proprietary password-based encryption algorithm.
-    It is based on password-based encryption as defined by the PKCS #5 standard, except that is uses triple DES instead of DES.
+    It is based on password-based encryption as defined by the PKCS #5 standard, except that it uses triple DES instead of DES.
     Here's how this algorithm works:
       1. Create random salt and split it in two halves. If the two halves are identical, invert one of them.
       2. Concatenate password with each of the halves.
@@ -162,8 +271,9 @@ def _sun_jce_derive_cipher_key_iv(password, salt, iteration_count):
          and use the result as the input to the next digest operation. The digest algorithm is MD5.
       4. After c iterations, use the 2 resulting digests as follows: The 16 bytes of the first digest and the 1st 8 bytes of the 2nd digest
          form the triple DES key, and the last 8 bytes of the 2nd digest form the IV.
-    See http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/6-b27/com/sun/crypto/provider/PBECipherCore.java#PBECipherCore.deriveCipherKey%28java.security.Key%29'''
-    # Note: unlike JKS, the JCE algorithm uses an ASCII string for the password, not a regular Java/UTF-16BE string; no need to double up on the password bytes
+    See http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/6-b27/com/sun/crypto/provider/PBECipherCore.java#PBECipherCore.deriveCipherKey%28java.security.Key%29
+    '''
+    # Note: unlike JKS, the JCE algorithm uses an ASCII?/UTF-8? string for the password, not a regular Java/UTF-16BE string; no need to double up on the password bytes
     if len(salt) != 8:
         raise ValueError("Expected 8-byte salt for JCE private key encryption algorithm (OID %s), found %d bytes" % (".".join(str(i) for i in SUN_JCE_ALGO_ID), len(salt)))
 
@@ -192,3 +302,11 @@ def _strip_pkcs5_padding(m):
         raise ValueError("Unable to strip PKCS5 padding: invalid padding found")
 
     return m[:-last_byte]
+
+def _read_java_obj(data, pos):
+
+    data_stream = StringIO.StringIO(data[pos:])
+    obj = javaobj.load(data_stream)
+    obj_size = data_stream.tell()
+
+    return obj, pos + obj_size

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pyasn1==0.1.7
+javaobj-py3==0.1.1

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     author="Kurt Rose",
     author_email="kurt@kurtrose.com",
     description='pure python jks file parser',
+    keywords="JKS JCEKS java keystore"
     license="MIT",
     url="http://github.com/doublereedkurt/pyjks",
     long_description=long_description,
@@ -22,5 +23,5 @@ setup(
         'License :: OSI Approved :: MIT License',
     ],
     packages=['jks'],
-    install_requires=['pyasn1'],
+    install_requires=['pyasn1', 'javaobj-py3'],
 )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except:
 
 setup(
     name='pyjks',
-    version='0.3.0.1',
+    version='0.3.1',
     author="Kurt Rose",
     author_email="kurt@kurtrose.com",
     description='pure python jks file parser',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
-from distutils.core import setup
 import os
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 try:
     readme_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'README.md')
@@ -14,7 +17,7 @@ setup(
     author="Kurt Rose",
     author_email="kurt@kurtrose.com",
     description='pure python jks file parser',
-    keywords="JKS JCEKS java keystore"
+    keywords="JKS JCEKS java keystore",
     license="MIT",
     url="http://github.com/doublereedkurt/pyjks",
     long_description=long_description,
@@ -24,4 +27,5 @@ setup(
     ],
     packages=['jks'],
     install_requires=['pyasn1', 'javaobj-py3'],
+    test_suite="tests.test_jks",
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+"""
+Test package for pyjks
+"""

--- a/tests/java/.gitignore
+++ b/tests/java/.gitignore
@@ -1,0 +1,4 @@
+.classpath
+.project
+.settings
+/target/

--- a/tests/java/pom.xml
+++ b/tests/java/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.pyjks</groupId>
+	<artifactId>pyjks</artifactId>
+	<version>1.0.0</version>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.9</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>1.10</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.4</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/tests/java/src/test/java/org/pyjks/JceKeystoreGeneratorTest.java
+++ b/tests/java/src/test/java/org/pyjks/JceKeystoreGeneratorTest.java
@@ -1,0 +1,94 @@
+package org.pyjks;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.security.KeyStore;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.DESKeySpec;
+import javax.crypto.spec.DESedeKeySpec;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.FileUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Prepares a bunch of JCEKS key stores on disk for pyjks to parse and verify the contents of.
+ */
+public class JceKeystoreGeneratorTest
+{
+	@BeforeClass
+	public static void setUpClass() throws Exception
+	{
+		File targetDirectory = new File("../keystores/jceks");
+		FileUtils.forceMkdir(targetDirectory);
+	}
+
+	protected void generateSecretKeyStore(String filepath, SecretKey secretKey) throws Exception
+	{
+		generateSecretKeyStore(filepath, secretKey, "12345678", "12345678", "mykey");
+	}
+
+	protected void generateSecretKeyStore(String filepath, SecretKey secretKey, String keystorePassword, String keyPassword, String alias) throws Exception
+	{
+		KeyStore ks = KeyStore.getInstance("JCEKS");
+		char[] ksPasswordChars = keystorePassword.toCharArray();
+		ks.load(null, ksPasswordChars);
+
+		if (secretKey != null)
+			ks.setEntry(alias, new KeyStore.SecretKeyEntry(secretKey), new KeyStore.PasswordProtection(keyPassword.toCharArray()));
+
+		FileOutputStream fos = new FileOutputStream(filepath);
+		ks.store(fos, ksPasswordChars);
+		fos.close();
+	}
+
+	@Test
+	public void jceks_empty() throws Exception
+	{
+		generateSecretKeyStore("../keystores/jceks/empty.jceks", null, "", "", "");
+	}
+
+	@Test
+	public void jceks_DES() throws Exception
+	{
+		// Note: SunJCE's DESKeyFactory will construct a DESKey from the input bytes given by the DESKeySpec after correcting for parity bits,
+		// so to ensure that the resulting key that gets stored is the exact same as our input bytes given here, we have to choose our
+		// input key bytes in such a way that the parity bit corrections don't affect it.
+		DESKeySpec keySpec = new DESKeySpec(Hex.decodeHex("4cf2fe915d082a43".toCharArray()));
+		SecretKey key = SecretKeyFactory.getInstance("DES").generateSecret(keySpec);
+
+		generateSecretKeyStore("../keystores/jceks/DES.jceks", key);
+	}
+
+	@Test
+	public void jceks_DESede() throws Exception
+	{
+		// Same comments as for the DES case
+		DESedeKeySpec keySpec = new DESedeKeySpec(Hex.decodeHex("675e5245e9673b4c8fc194ceec433b318c45c2e0675e5245".toCharArray()));
+		SecretKey key = SecretKeyFactory.getInstance("DESede").generateSecret(keySpec);
+
+		generateSecretKeyStore("../keystores/jceks/DESede.jceks", key);
+	}
+
+	@Test
+	public void jceks_PBKDF2() throws Exception
+	{
+		PBEKeySpec keySpec = new PBEKeySpec("CCC".toCharArray(), new byte[]{1,2,3,4,5,6,7,8}, 999, 256);
+		SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA512");
+		SecretKey key = factory.generateSecret(keySpec);
+
+		generateSecretKeyStore("../keystores/jceks/PBKDF2.jceks", key);
+	}
+
+	@Test
+	public void jceks_AES() throws Exception
+	{
+		generateSecretKeyStore("../keystores/jceks/AES128.jceks", new SecretKeySpec(Hex.decodeHex("666e0221cc44c1fc4aabf458f9dfdd3c".toCharArray()), "AES"));
+		generateSecretKeyStore("../keystores/jceks/AES256.jceks", new SecretKeySpec(Hex.decodeHex("e7d7c262668221787b6b5a0f687712fde4be52e9e7d7c262668221787b6b5a0f".toCharArray()), "AES"));
+	}
+
+}

--- a/tests/test_jks.py
+++ b/tests/test_jks.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# vim: set ai et ts=4 sw=4 sts=4:
+"""
+Tests for pyjks
+"""
+
+import os, sys
+import jks
+import unittest
+import subprocess
+from pprint import pprint
+
+class cd:
+    def __init__(self, newdir):
+        self.newdir = newdir
+    def __enter__(self):
+        self.olddir = os.getcwd()
+        os.chdir(self.newdir)
+    def __exit__(self, etype, value, trace):
+        os.chdir(self.olddir)
+
+class AbstractTest(unittest.TestCase):
+    def find_private_key(self, ks, alias):
+        for pk in ks.private_keys:
+            if pk.alias == alias:
+                return pk
+        return None
+
+    def find_secret_key(self, ks, alias):
+        for sk in ks.secret_keys:
+            if sk.alias == alias:
+                return sk
+        return None
+
+    def find_cert(self, ks, alias):
+        for c in ks.certs:
+            if c.alias == alias:
+                return c
+        return None
+
+class JceksTests(AbstractTest):
+    @classmethod
+    def setUpClass(cls):
+        # Note: cwd is expected to be in the top-level pyjks directory
+        test_dir = os.path.dirname(__file__)
+        java_path = os.path.join(test_dir, "java")
+        with cd(java_path):
+            subprocess.call(["mvn", "test"])
+        # back at the top-level pyjks directory
+
+    def test_empty_store(self):
+        store = jks.KeyStore.load("tests/keystores/jceks/empty.jceks", "")
+        self.assertEqual(len(store.private_keys), 0)
+        self.assertEqual(len(store.secret_keys), 0)
+        self.assertEqual(len(store.certs), 0)
+
+    def test_des_secret_key(self):
+        store = jks.KeyStore.load("tests/keystores/jceks/DES.jceks", "12345678")
+        sk = self.find_secret_key(store, "mykey")
+        self.assertEqual(sk.key, "\x4c\xf2\xfe\x91\x5d\x08\x2a\x43")
+
+    def test_desede_secret_key(self):
+        store = jks.KeyStore.load("tests/keystores/jceks/DESede.jceks", "12345678")
+        sk = self.find_secret_key(store, "mykey")
+        self.assertEqual(sk.key, "\x67\x5e\x52\x45\xe9\x67\x3b\x4c\x8f\xc1\x94\xce\xec\x43\x3b\x31\x8c\x45\xc2\xe0\x67\x5e\x52\x45")
+
+    def test_aes128_secret_key(self):
+        store = jks.KeyStore.load("tests/keystores/jceks/AES128.jceks", "12345678")
+        sk = self.find_secret_key(store, "mykey")
+        self.assertEqual(sk.key, "\x66\x6e\x02\x21\xcc\x44\xc1\xfc\x4a\xab\xf4\x58\xf9\xdf\xdd\x3c")
+
+    def test_aes256_secret_key(self):
+        store = jks.KeyStore.load("tests/keystores/jceks/AES256.jceks", "12345678")
+        sk = self.find_secret_key(store, "mykey")
+        self.assertEqual(sk.key, "\xe7\xd7\xc2\x62\x66\x82\x21\x78\x7b\x6b\x5a\x0f\x68\x77\x12\xfd\xe4\xbe\x52\xe9\xe7\xd7\xc2\x62\x66\x82\x21\x78\x7b\x6b\x5a\x0f")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the ability to parse SecretKey entries as created by the default SunJCE provider (i.e. as created by keytool).

Some notes:
  - Contains an attempt at version number bumping and unit testing, but I have little to no experience with publishing python packages, so feel free to make corrections/improvements
  - Relies on javaobj-py3 to read serialized Java objects. This version currently emits a slightly annoying warning about remaining input bytes when deserializing Java objects, because JCEKS keystores effectively just embed them in the middle of the binary. I intend to add a feature request to get a "lenient" mode in which it doesn't log this warning.