### PR TITLE
README.md: Make print_pem function in sample code work under Python 3…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Reading a JKS or JCEKS keystore and dumping out its contents in the PEM format:
 import sys, base64, textwrap
 import jks
 
-def print_pem(data, type):
+def print_pem(der_bytes, type):
     print "-----BEGIN %s-----" % type
-    print "\r\n".join(textwrap.wrap(base64.b64encode(data), 64))
+    print "\r\n".join(textwrap.wrap(base64.b64encode(der_bytes).decode('ascii'), 64))
     print "-----END %s-----" % type
 
 ks = jks.KeyStore.load("keystore.jks", "XXXXXXXX")


### PR DESCRIPTION
… (after prior trivial changes, e.g. print() calls) (cfr. issue #11)

Fix for issue #11. Verified that updated print_pem function works when given a Python 3 'bytes' object and a Python 2 'str' as before.