### PR TITLE
Corrected PBEWithMD5AndTripleDES decryption to account for historical bug in JCE salt-inversion routine

### DIFF
--- a/tests/java/src/test/java/org/pyjks/JceKeystoreGeneratorTest.java
+++ b/tests/java/src/test/java/org/pyjks/JceKeystoreGeneratorTest.java
@@ -86,12 +86,7 @@ public class JceKeystoreGeneratorTest extends PyJksTestCase
 		String password = "12345678";
 
 		// encrypt the enclosed serialized object with PBEWithMD5AndTripleDES, as the Sun JCE key store implementation does
-		PBEParameterSpec pbeParamSpec = new PBEParameterSpec(new byte[]{83, 79, 95, 83, 65, 76, 84, 89}, 42);
-		PBEKeySpec pbeKeySpec = new PBEKeySpec(password.toCharArray());
-		SecretKey pbeKey = SecretKeyFactory.getInstance("PBEWithMD5AndTripleDES").generateSecret(pbeKeySpec);
-
-		Cipher cipher = Cipher.getInstance("PBEWithMD5AndTripleDES");
-		cipher.init(Cipher.ENCRYPT_MODE, pbeKey, pbeParamSpec);
+		Cipher cipher = getPBEWithMD5AndTripleDESCipher(password, new byte[]{83, 79, 95, 83, 65, 76, 84, 89}, 42);
 
 		SealedObject so = new SealedObject(new DummyObject(), cipher);
 		generateManualSealedObjectStore(filename, password, alias, so);

--- a/tests/java/src/test/java/org/pyjks/KeystoreGeneratorTest.java
+++ b/tests/java/src/test/java/org/pyjks/KeystoreGeneratorTest.java
@@ -25,17 +25,14 @@ public class KeystoreGeneratorTest extends PyJksTestCase
 	@Test
 	public void generate_empty() throws Exception
 	{
-		generatePrivateKeyStore("JKS",   "../keystores/jks/empty.jks",     null, null, "", "", "");
-		generatePrivateKeyStore("JCEKS", "../keystores/jceks/empty.jceks", null, null, "", "", "");
+		generateKeyStore("JKS",   "../keystores/jks/empty.jks", null, null, "");
+		generateKeyStore("JCEKS", "../keystores/jceks/empty.jceks", null, null, "");
 	}
 
 	@Test
 	public void generate_RSA1024() throws Exception
 	{
-		KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
-		keyPairGenerator.initialize(1024);
-		KeyPair keyPair = keyPairGenerator.generateKeyPair();
-
+		KeyPair keyPair = generateKeyPair("RSA", 1024);
 		Certificate cert = createSelfSignedCertificate(keyPair, "CN=RSA1024");
 		Certificate[] certs = new Certificate[]{cert};
 
@@ -48,9 +45,7 @@ public class KeystoreGeneratorTest extends PyJksTestCase
 	@Test
 	public void generate_RSA2048_3certs() throws Exception
 	{
-		KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
-		keyPairGenerator.initialize(2048);
-		KeyPair keyPair = keyPairGenerator.generateKeyPair();
+		KeyPair keyPair = generateKeyPair("RSA", 2048);
 
 		// these do not form a chain, but that doesn't really matter for our purposes
 		Certificate cert1 = createSelfSignedCertificate(keyPair, "CN=RSA2048, O=1");
@@ -72,11 +67,7 @@ public class KeystoreGeneratorTest extends PyJksTestCase
 	@Test
 	public void generate_DSA2048() throws Exception
 	{
-		KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("DSA");
-		keyPairGenerator.initialize(2048);
-		KeyPair keyPair = keyPairGenerator.generateKeyPair();
-
-		// these do not form a chain, but that doesn't really matter for our purposes
+		KeyPair keyPair = generateKeyPair("DSA", 2048);
 		Certificate cert = createSelfSignedCertificate(keyPair, "CN=DSA2048");
 		Certificate[] certs = new Certificate[]{ cert };
 
@@ -91,9 +82,7 @@ public class KeystoreGeneratorTest extends PyJksTestCase
 	{
 		// The JKS keystore protector algorithm says that the password is expected to be ASCII but it doesn't enforce that,
 		// so there's nothing stopping you from using non-ASCII passwords anyway. Let's generate one and see if we can parse it.
-		KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
-		keyPairGenerator.initialize(2048);
-		KeyPair keyPair = keyPairGenerator.generateKeyPair();
+		KeyPair keyPair = generateKeyPair("RSA", 2048);
 
 		Certificate cert = createSelfSignedCertificate(keyPair, "CN=non_ascii_password");
 		Certificate[] certs = new Certificate[]{cert};

--- a/tests/java/src/test/java/org/pyjks/MiscTest.java
+++ b/tests/java/src/test/java/org/pyjks/MiscTest.java
@@ -1,0 +1,23 @@
+package org.pyjks;
+
+import org.junit.Test;
+
+public class MiscTest extends PyJksTestCase
+{
+	/**
+	 * Encrypt some known data with PBEWithMD5AndTripleDES to verify correct decryption in python.
+	 * In particular, exercise the edge case where the two salt halves are equal, because there's a bug in the JCE lurking there
+	 * (see the python side for details)
+	 */
+	@Test
+	public void generate_PBEWithMD5AndTripleDES_samples() throws Exception
+	{
+		byte[] output1 = encryptPBEWithMD5AndTripleDES("sample".getBytes(), "my_password", new byte[]{1,2,3,4,5,6,7,8}, 42);
+		byte[] output2 = encryptPBEWithMD5AndTripleDES("sample".getBytes(), "my_password", new byte[]{1,2,3,4,1,2,3,4}, 42); // special case for SunJCE's PBEWithMD5AndTripleDES: identical salt halves
+		byte[] output3 = encryptPBEWithMD5AndTripleDES("sample".getBytes(), "my_password", new byte[]{1,2,3,4,1,2,3,5}, 42); // control case for the previous one
+
+		System.out.println(toPythonString(output1));
+		System.out.println(toPythonString(output2));
+		System.out.println(toPythonString(output3));
+	}
+}

--- a/tests/java/src/test/java/org/pyjks/PyJksTestCase.java
+++ b/tests/java/src/test/java/org/pyjks/PyJksTestCase.java
@@ -23,7 +23,11 @@ import java.security.interfaces.RSAPrivateKey;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.PBEParameterSpec;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.bouncycastle.asn1.x500.X500Name;
@@ -306,5 +310,23 @@ public class PyJksTestCase
 		{
 			Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);
 		}
+	}
+
+	protected Cipher getPBEWithMD5AndTripleDESCipher(String password, byte[] salt, int iterationCount) throws Exception
+	{
+		// encrypt the enclosed serialized object with PBEWithMD5AndTripleDES, as the Sun JCE key store implementation does
+		PBEParameterSpec pbeParamSpec = new PBEParameterSpec(salt, iterationCount);
+		PBEKeySpec pbeKeySpec = new PBEKeySpec(password.toCharArray());
+		SecretKey pbeKey = SecretKeyFactory.getInstance("PBEWithMD5AndTripleDES").generateSecret(pbeKeySpec);
+
+		Cipher cipher = Cipher.getInstance("PBEWithMD5AndTripleDES");
+		cipher.init(Cipher.ENCRYPT_MODE, pbeKey, pbeParamSpec);
+		return cipher;
+	}
+
+	protected byte[] encryptPBEWithMD5AndTripleDES(byte[] input, String password, byte[] salt, int iterationCount) throws Exception
+	{
+		Cipher c = getPBEWithMD5AndTripleDESCipher(password, salt, iterationCount);
+		return c.doFinal(input);
 	}
 }

--- a/tests/java/src/test/java/org/pyjks/PyJksTestCase.java
+++ b/tests/java/src/test/java/org/pyjks/PyJksTestCase.java
@@ -9,6 +9,7 @@ import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.security.DigestOutputStream;
 import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -20,6 +21,8 @@ import java.security.cert.X509Certificate;
 import java.security.interfaces.DSAPrivateKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 import javax.crypto.SecretKey;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -36,7 +39,7 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
  */
 public class PyJksTestCase
 {
-	public String toPythonString(byte[] data, int bytesPerLine, String leftPadding)
+	public static String toPythonString(byte[] data, int bytesPerLine, String leftPadding)
 	{
 		char[] hexChars = new char[]{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e','f'};
 		leftPadding = (leftPadding == null ? "" : leftPadding);
@@ -59,7 +62,7 @@ public class PyJksTestCase
 		return sb.toString();
 	}
 
-	public String toPythonString(byte[] data)
+	public static String toPythonString(byte[] data)
 	{
 		return toPythonString(data, 32, "");
 	}
@@ -100,6 +103,53 @@ public class PyJksTestCase
 		FileUtils.writeStringToFile(new File(filename), sb.toString());
 	}
 
+	protected KeyPair generateKeyPair(String algorithm, int size) throws Exception
+	{
+		KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(algorithm);
+		keyPairGenerator.initialize(size);
+		return keyPairGenerator.generateKeyPair();
+	}
+
+	protected void generateKeyStore(String storeType, String filepath, Map<String, KeyStore.Entry> entriesByAlias, Map<String, String> entryPasswordsByAlias, String storePassword) throws Exception
+	{
+		// avoid the need for some null checks in the remainder of the code below
+		if (entriesByAlias == null)
+			entriesByAlias = new HashMap<String, KeyStore.Entry>();
+		if (entryPasswordsByAlias == null)
+			entryPasswordsByAlias = new HashMap<String, String>();
+
+		KeyStore ks = KeyStore.getInstance(storeType);
+		char[] storePasswordChars = storePassword.toCharArray();
+		ks.load(null, storePasswordChars);
+
+		for (String alias : entriesByAlias.keySet())
+		{
+			KeyStore.Entry entry = entriesByAlias.get(alias);
+			if (entry == null)
+				continue;
+
+			// trusted certificates don't need password protection (and will complain if you provide it)
+			KeyStore.PasswordProtection passwordProtection = null;
+			if (!(entry instanceof KeyStore.TrustedCertificateEntry))
+			{
+				String entryPassword = entryPasswordsByAlias.get(alias);
+				if (entryPassword == null)
+					entryPassword = storePassword;
+
+				// Note: there's no point specifying a protection algorithm/parameters to the KeyStore.PasswordProtection instance,
+				// the default KeyStoreSpi.setEntry implementation uses it only to grab the password and nothing else.
+				// Only the PKCS12 keystore SPI appears to honor custom protection algorithm/parameters.
+				passwordProtection = new KeyStore.PasswordProtection(entryPassword.toCharArray());
+			}
+
+			ks.setEntry(alias, entry, passwordProtection);
+		}
+
+		FileOutputStream fos = new FileOutputStream(filepath);
+		ks.store(fos, storePasswordChars);
+		fos.close();
+	}
+
 	protected void generatePrivateKeyStore(String storeType, String filepath, PrivateKey privateKey, Certificate[] chain) throws Exception
 	{
 		generatePrivateKeyStore(storeType, filepath, privateKey, chain, "12345678", "12345678", "mykey");
@@ -107,16 +157,16 @@ public class PyJksTestCase
 
 	protected void generatePrivateKeyStore(String storeType, String filepath, PrivateKey privateKey, Certificate[] chain, String storePassword, String keyPassword, String alias) throws Exception
 	{
-		KeyStore ks = KeyStore.getInstance(storeType);
-		char[] ksPasswordChars = storePassword.toCharArray();
-		ks.load(null, ksPasswordChars);
+		Map<String, KeyStore.Entry> entriesByAlias = new HashMap<String, KeyStore.Entry>();
+		Map<String, String> passwordsByAlias = new HashMap<String, String>();
 
 		if (privateKey != null)
-			ks.setEntry(alias, new KeyStore.PrivateKeyEntry(privateKey, chain), new KeyStore.PasswordProtection(keyPassword.toCharArray()));
+		{
+			entriesByAlias.put(alias, new KeyStore.PrivateKeyEntry(privateKey, chain));
+			passwordsByAlias.put(alias, keyPassword);
+		}
 
-		FileOutputStream fos = new FileOutputStream(filepath);
-		ks.store(fos, ksPasswordChars);
-		fos.close();
+		generateKeyStore(storeType, filepath, entriesByAlias, passwordsByAlias, storePassword);
 	}
 
 	protected void generateCertKeyStore(String storeType, String filepath, Certificate cert) throws Exception
@@ -131,19 +181,34 @@ public class PyJksTestCase
 
 	protected void generateCertsKeyStore(String storeType, String filepath, Certificate[] certs, String[] aliases, String storePassword) throws Exception
 	{
-		KeyStore ks = KeyStore.getInstance(storeType);
-		char[] ksPasswordChars = storePassword.toCharArray();
-		ks.load(null, ksPasswordChars);
+		Map<String, KeyStore.Entry> entriesByAlias = new HashMap<String, KeyStore.Entry>();
 
-		if (certs != null)
+		if (certs != null && aliases != null)
 		{
-			for (int i=0; i<certs.length; i++)
-				ks.setEntry(aliases[i], new KeyStore.TrustedCertificateEntry(certs[i]), null);
+			for (int i=0; i < certs.length; i++)
+				entriesByAlias.put(aliases[i], new KeyStore.TrustedCertificateEntry(certs[i]));
 		}
 
-		FileOutputStream fos = new FileOutputStream(filepath);
-		ks.store(fos, ksPasswordChars);
-		fos.close();
+		generateKeyStore(storeType, filepath, entriesByAlias, null, storePassword);
+	}
+
+	protected void generateSecretKeyStore(String filepath, SecretKey secretKey) throws Exception
+	{
+		generateSecretKeyStore(filepath, secretKey, "12345678", "12345678", "mykey");
+	}
+
+	protected void generateSecretKeyStore(String filepath, SecretKey secretKey, String storePassword, String keyPassword, String alias) throws Exception
+	{
+		Map<String, KeyStore.Entry> entriesByAlias = new HashMap<String, KeyStore.Entry>();
+		Map<String, String> passwordsByAlias = new HashMap<String, String>();
+
+		if (secretKey != null)
+		{
+			entriesByAlias.put(alias, new KeyStore.SecretKeyEntry(secretKey));
+			passwordsByAlias.put(alias, keyPassword);
+		}
+
+		generateKeyStore("JCEKS", filepath, entriesByAlias, passwordsByAlias, storePassword);
 	}
 
 	protected MessageDigest getJceStoreDigest(String keystorePassword)
@@ -175,28 +240,6 @@ public class PyJksTestCase
 			throw new RuntimeException(e);
 		}
 		return md;
-	}
-
-	protected void generateSecretKeyStore(String filepath, SecretKey secretKey) throws Exception
-	{
-		generateSecretKeyStore(filepath, secretKey, "12345678", "12345678", "mykey");
-	}
-
-	protected void generateSecretKeyStore(String filepath, SecretKey secretKey, String keystorePassword, String keyPassword, String alias) throws Exception
-	{
-		KeyStore ks = KeyStore.getInstance("JCEKS");
-		char[] ksPasswordChars = keystorePassword.toCharArray();
-		ks.load(null, ksPasswordChars);
-
-		// Note: there's no point specifying a protection algorithm/parameters to the KeyStore.PasswordProtection instance,
-		// the default KeyStoreSpi.setEntry implementation uses it only to grab the password and nothing else.
-		// Only the PKCS12 keystore SPI appears to honor custom protection algorithm/parameters.
-		if (secretKey != null)
-			ks.setEntry(alias, new KeyStore.SecretKeyEntry(secretKey), new KeyStore.PasswordProtection(keyPassword.toCharArray()));
-
-		FileOutputStream fos = new FileOutputStream(filepath);
-		ks.store(fos, ksPasswordChars);
-		fos.close();
 	}
 
 	/**

--- a/tests/test_jks.py
+++ b/tests/test_jks.py
@@ -53,6 +53,11 @@ class AbstractTest(unittest.TestCase):
         for i in range(len(certs)):
             self.assertEqual(pk.cert_chain[i][1], certs[i])
 
+    def check_secret_key_equal(self, sk, algorithm_name, key_size, key_bytes):
+        self.assertEqual(sk.algorithm, algorithm_name)
+        self.assertEqual(sk.size, key_size)
+        self.assertEqual(sk.key, key_bytes)
+
 class JksTests(AbstractTest):
     def test_empty_store(self):
         store = jks.KeyStore.load("tests/keystores/jks/empty.jks", "")
@@ -136,41 +141,31 @@ class JceOnlyTests(AbstractTest):
         store = jks.KeyStore.load("tests/keystores/jceks/DES.jceks", "12345678")
         sk = self.find_secret_key(store, "mykey")
         self.assertEqual(store.store_type, "jceks")
-        self.assertEqual(sk.key, b"\x4c\xf2\xfe\x91\x5d\x08\x2a\x43")
-        self.assertEqual(sk.algorithm, "DES")
-        self.assertEqual(sk.size, 64)
+        self.check_secret_key_equal(sk, "DES", 64, b"\x4c\xf2\xfe\x91\x5d\x08\x2a\x43")
 
     def test_desede_secret_key(self):
         store = jks.KeyStore.load("tests/keystores/jceks/DESede.jceks", "12345678")
         sk = self.find_secret_key(store, "mykey")
         self.assertEqual(store.store_type, "jceks")
-        self.assertEqual(sk.key, b"\x67\x5e\x52\x45\xe9\x67\x3b\x4c\x8f\xc1\x94\xce\xec\x43\x3b\x31\x8c\x45\xc2\xe0\x67\x5e\x52\x45")
-        self.assertEqual(sk.algorithm, "DESede")
-        self.assertEqual(sk.size, 192)
+        self.check_secret_key_equal(sk, "DESede", 192, b"\x67\x5e\x52\x45\xe9\x67\x3b\x4c\x8f\xc1\x94\xce\xec\x43\x3b\x31\x8c\x45\xc2\xe0\x67\x5e\x52\x45")
 
     def test_aes128_secret_key(self):
         store = jks.KeyStore.load("tests/keystores/jceks/AES128.jceks", "12345678")
         sk = self.find_secret_key(store, "mykey")
         self.assertEqual(store.store_type, "jceks")
-        self.assertEqual(sk.key, b"\x66\x6e\x02\x21\xcc\x44\xc1\xfc\x4a\xab\xf4\x58\xf9\xdf\xdd\x3c")
-        self.assertEqual(sk.algorithm, "AES")
-        self.assertEqual(sk.size, 128)
+        self.check_secret_key_equal(sk, "AES", 128, b"\x66\x6e\x02\x21\xcc\x44\xc1\xfc\x4a\xab\xf4\x58\xf9\xdf\xdd\x3c")
 
     def test_aes256_secret_key(self):
         store = jks.KeyStore.load("tests/keystores/jceks/AES256.jceks", "12345678")
         sk = self.find_secret_key(store, "mykey")
         self.assertEqual(store.store_type, "jceks")
-        self.assertEqual(sk.key, b"\xe7\xd7\xc2\x62\x66\x82\x21\x78\x7b\x6b\x5a\x0f\x68\x77\x12\xfd\xe4\xbe\x52\xe9\xe7\xd7\xc2\x62\x66\x82\x21\x78\x7b\x6b\x5a\x0f")
-        self.assertEqual(sk.algorithm, "AES")
-        self.assertEqual(sk.size, 256)
+        self.check_secret_key_equal(sk, "AES", 256, b"\xe7\xd7\xc2\x62\x66\x82\x21\x78\x7b\x6b\x5a\x0f\x68\x77\x12\xfd\xe4\xbe\x52\xe9\xe7\xd7\xc2\x62\x66\x82\x21\x78\x7b\x6b\x5a\x0f")
 
     def test_pbkdf2_hmac_sha1(self):
         store = jks.KeyStore.load("tests/keystores/jceks/PBKDF2WithHmacSHA1.jceks", "12345678")
         sk = self.find_secret_key(store, "mykey")
         self.assertEqual(store.store_type, "jceks")
-        self.assertEqual(sk.key, b"\x57\x95\x36\xd9\xa2\x7f\x7e\x31\x4e\xf4\xe3\xff\xa5\x76\x26\xef\xe6\x70\xe8\xf4\xd2\x96\xcd\x31\xba\x1a\x82\x7d\x9a\x3b\x1e\xe1")
-        self.assertEqual(sk.algorithm, "PBKDF2WithHmacSHA1")
-        self.assertEqual(sk.size, 256)
+        self.check_secret_key_equal(sk, "PBKDF2WithHmacSHA1", 256, b"\x57\x95\x36\xd9\xa2\x7f\x7e\x31\x4e\xf4\xe3\xff\xa5\x76\x26\xef\xe6\x70\xe8\xf4\xd2\x96\xcd\x31\xba\x1a\x82\x7d\x9a\x3b\x1e\xe1")
 
     def test_unknown_type_of_sealed_object(self):
         """Verify that an exception is raised when encountering a (serialized) Java object inside a SecretKey entry that is not of type javax.crypto.SealedObject"""

--- a/tests/test_jks.py
+++ b/tests/test_jks.py
@@ -193,5 +193,10 @@ class MiscTests(AbstractTest):
         self.assertRaises(jks.BadPaddingException, jks.jks._strip_pkcs5_padding, b"\x07\x07\x07\x07\x07\x07\x07")
         self.assertRaises(jks.BadPaddingException, jks.jks._strip_pkcs5_padding, b"\x00\x00\x00\x00\x00\x00\x00\x00")
 
+    def test_sun_jce_pbe_decrypt(self):
+        self.assertEqual(b"sample", jks.jks._sun_jce_pbe_decrypt(b"\xc4\x20\x59\xac\x54\x03\xc7\xbf", "my_password", b"\x01\x02\x03\x04\x05\x06\x07\x08", 42))
+        self.assertEqual(b"sample", jks.jks._sun_jce_pbe_decrypt(b"\xef\x9f\xbd\xc5\x91\x5f\x49\x50", "my_password", b"\x01\x02\x03\x04\x01\x02\x03\x05", 42))
+        self.assertEqual(b"sample", jks.jks._sun_jce_pbe_decrypt(b"\x72\x8f\xd8\xcc\x21\x41\x25\x80", "my_password", b"\x01\x02\x03\x04\x01\x02\x03\x04", 42))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The description of PBEWithMD5AndTripleDES in the OpenJDK sources says to invert the first salt half if the two halves are the same. Turns out that the original JCE implementation way back for JDK 1.2 had a bug in the code for inverting that salt half, causing a different result. At least the bug has been consistently carried along through all JRE versions though.

Interestingly, the OpenJDK sources give a hint as to what the cause of the bug might have been:
```
for (i=0; i<2; i++) {
    byte tmp = salt[i];
    salt[i] = salt[3-i];
    salt[3-1] = tmp;     // <-- typo '1' instead of 'i'
}
```
This commit fixes the decryption routine to correctly decrypt PBEWithMD5AndTripleDES when such a salt with identical halves was used.