### PR TITLE
Python 2.6 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is better:
 
 ## Requirements:
 
- * Python 2.7+ or Python 3.3+
+ * Python 2.6+ or Python 3.3+
  * pyasn1 0.1.7+
  * pyasn1_modules 0.0.8+
  * javaobj-py3 0.1.4+

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is better:
 
 ## Requirements:
 
- * Python 2.7+ or Python 3.4+
+ * Python 2.7+ or Python 3.3+
  * pyasn1 0.1.7+
  * pyasn1_modules 0.0.8+
  * javaobj-py3 0.1.4+

--- a/jks/bks.py
+++ b/jks/bks.py
@@ -257,7 +257,7 @@ class BksKeyStore(KeyStore):
             if _type == 0:
                 break
 
-            alias, pos = cls._read_utf(data, pos)
+            alias, pos = cls._read_utf(data, pos, kind="entry alias")
             timestamp = int(b8.unpack_from(data, pos)[0]); pos += 8
             chain_length = b4.unpack_from(data, pos)[0]; pos += 4
 
@@ -295,7 +295,7 @@ class BksKeyStore(KeyStore):
 
     @classmethod
     def _read_bks_cert(cls, data, pos, store_type):
-        cert_type, pos = cls._read_utf(data, pos)
+        cert_type, pos = cls._read_utf(data, pos, kind="certificate type")
         cert_data, pos = cls._read_data(data, pos)
         entry = BksTrustedCertEntry(type=cert_type, cert=cert_data, store_type=store_type)
         return entry, pos
@@ -304,8 +304,8 @@ class BksKeyStore(KeyStore):
     def _read_bks_key(cls, data, pos, store_type):
         """Given a data stream, attempt to parse a stored BKS key entry at the given position, and return it as a BksKeyEntry."""
         key_type = b1.unpack_from(data, pos)[0]; pos += 1
-        key_format, pos = BksKeyStore._read_utf(data, pos)
-        key_algorithm, pos = BksKeyStore._read_utf(data, pos)
+        key_format, pos = BksKeyStore._read_utf(data, pos, kind="key format")
+        key_algorithm, pos = BksKeyStore._read_utf(data, pos, kind="key algorithm")
         key_enc, pos = BksKeyStore._read_data(data, pos)
 
         entry = BksKeyEntry(key_type, key_format, key_algorithm, key_enc, store_type=store_type)

--- a/jks/sun_crypto.py
+++ b/jks/sun_crypto.py
@@ -19,7 +19,7 @@ def jks_pkey_decrypt(data, password_str):
     xoring = zip(data, _jks_keystream(iv, password_bytes))
     key = bytearray([d^k for d,k in xoring])
 
-    if hashlib.sha1(password_bytes + key).digest() != check:
+    if hashlib.sha1(bytes(password_bytes + key)).digest() != check:
         raise BadHashCheckException("Bad hash check on private key; wrong password?")
     key = bytes(key)
     return key
@@ -28,7 +28,8 @@ def _jks_keystream(iv, password):
     """Helper keystream generator for _jks_pkey_decrypt"""
     cur = iv
     while 1:
-        cur = bytearray(hashlib.sha1(password + cur).digest()) # make sure we iterate over ints in both Py2 and Py3
+        xhash = hashlib.sha1(bytes(password + cur)) # hashlib.sha1 in python 2.6 does not accept a bytearray argument
+        cur = bytearray(xhash.digest()) # make sure we iterate over ints in both Py2 and Py3
         for byte in cur:
             yield byte
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyasn1==0.1.7
 pyasn1_modules==0.0.8
-javaobj-py3==0.1.4
+javaobj-py3==0.2.1
 pycrypto==2.6.1
 twofish==0.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # 2.6 delayed by javaobj see issue #23
-envlist = py27,py34,pypy
+envlist = py27,py33,py34,pypy
 [testenv]
 changedir = .tox
 deps = -rrequirements-test.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # 2.6 delayed by javaobj see issue #23
-envlist = py27,py33,py34,pypy
+envlist = py26,py27,py33,py34,pypy
 [testenv]
 changedir = .tox
 deps = -rrequirements-test.txt


### PR DESCRIPTION
 - Allows pyjks to run under Python 2.6. Passes all current test cases.
 - Tweaks the minimum required Python 3 version to 3.3 (originally declared as 3.4 because I didn't have a 3.3 installation at the time)

Note: updates the javaobj-py3 dependency to 0.2.1 because it too had to be made Python 2.6 compatible (see https://github.com/tcalmant/python-javaobj/pull/8).